### PR TITLE
Update studio-macos.sh

### DIFF
--- a/web-ui/src/main/resources/studio-macos.sh
+++ b/web-ui/src/main/resources/studio-macos.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+STUDIO_PATH="`dirname \"$0\"`"
 DOT_STUDIO=$HOME/.studio
 LOCAL_LUNIITHEQUE="$HOME/Library/Application Support/Luniitheque"
 
@@ -15,7 +16,7 @@ if [ ! -e "$DOT_STUDIO/lib/lunii-device-gateway.jar" ]; then cp "$LOCAL_LUNIITHE
 if [ ! -e "$DOT_STUDIO/lib/lunii-device-wrapper.jar" ]; then cp "$LOCAL_LUNIITHEQUE/lib/lunii-device-wrapper.jar" $DOT_STUDIO/lib/; fi
 
 # Copy agent and metadata JARs
-cp ./agent/studio-agent-${project.version}-jar-with-dependencies.jar $DOT_STUDIO/agent/studio-agent.jar
-cp ./agent/studio-metadata-${project.version}-jar-with-dependencies.jar $DOT_STUDIO/agent/studio-metadata.jar
+cp $STUDIO_PATH/agent/studio-agent-${project.version}-jar-with-dependencies.jar $DOT_STUDIO/agent/studio-agent.jar
+cp $STUDIO_PATH/agent/studio-metadata-${project.version}-jar-with-dependencies.jar $DOT_STUDIO/agent/studio-metadata.jar
 
-java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -Dfile.encoding=UTF-8 -cp ${project.build.finalName}.jar:lib/*:$DOT_STUDIO/lib/*:. io.vertx.core.Launcher run ${vertx.main.verticle}
+java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -Dfile.encoding=UTF-8 -cp $STUDIO_PATH/${project.build.finalName}.jar:$STUDIO_PATH/lib/*:$DOT_STUDIO/lib/*:. io.vertx.core.Launcher run ${vertx.main.verticle}


### PR DESCRIPTION
This change aims to make the app a tiny bit more user friendly to run on macOS by simply being able to run the `studio-macos.sh` file from the Finder (or from a shortcut on the Dock for example).

Currently, running the `studio-macos.sh` script from anywhere outside the STUdio folder outputs the following errors:

```console
cp: ./agent/studio-agent-0.1.11-jar-with-dependencies.jar: No such file or directory
cp: ./agent/studio-metadata-0.1.11-jar-with-dependencies.jar: No such file or directory
Error: Could not find or load main class io.vertx.core.Launcher
Caused by: java.lang.ClassNotFoundException: io.vertx.core.Launcher
logout
Saving session...
...copying shared history...
...saving history...truncating history files...
...completed.
```

Prefixing the problematic paths by the executable path fixes the problem.