### PR TITLE
display pack's uuid instead of MISSING_PACK_TITLE on the home page

### DIFF
--- a/web-ui/javascript/src/components/PackLibrary.js
+++ b/web-ui/javascript/src/components/PackLibrary.js
@@ -373,7 +373,7 @@ class PackLibrary extends React.Component {
                                         {pack.official && <div className="pack-ribbon"><span>{t('library.official')}</span></div>}
                                     </div>
                                     <div>
-                                        <span>{pack.title || pack.uuid}</span>&nbsp;
+                                        <span>{pack.title && pack.title !== "MISSING_PACK_TITLE" ? pack.title : pack.uuid}</span>&nbsp;
                                         <button className="pack-action" onClick={this.onRemovePackFromDevice(pack.uuid)}>
                                             <span className="glyphicon glyphicon-trash"
                                                   title={t('library.device.removePack')} />
@@ -413,7 +413,7 @@ class PackLibrary extends React.Component {
                                         {pack.official && <div className="pack-ribbon"><span>{t('library.official')}</span></div>}
                                     </div>
                                     <div>
-                                        <span>{pack.title || pack.uuid}</span>&nbsp;
+                                        <span>{pack.title && pack.title !== "MISSING_PACK_TITLE" ? pack.title : pack.uuid}</span>&nbsp;
                                         {pack.format === 'binary' && <button className="pack-action" onClick={this.onConvertLibraryPack(pack)}>
                                             <span className="glyphicon glyphicon-cog"
                                                   title={t('library.local.convertPack')} />


### PR DESCRIPTION
When several custom story packs are fetched from a Lunii, all non-enriched-with-metadata packs have MISSING_PACK_TITLE as title (this is the default value, see [ArchiveStoryPackWriter.java#L55](https://github.com/marian-m12l/studio/blob/e9fb1b604f766ddc4d01fd990b95f9544364af7f/core/src/main/java/studio/core/v1/writer/archive/ArchiveStoryPackWriter.java#L55), or [ArchiveStoryPackWriter.java#L46](https://github.com/marian-m12l/studio/blob/d405c39e9e05c707c6de0b687933c090f049ddba/core/src/main/java/studio/core/v1/writer/archive/ArchiveStoryPackWriter.java#L46) before enrichment).
<img width="420" alt="missing" src="https://user-images.githubusercontent.com/26461464/82950528-beef5e80-9fa5-11ea-9192-42092832aa58.png">

Even if uuids are not really human friendly, they still give more information than "MISSING_PACK_TITLE", and allow to distinguish story packs from each other. 
<img width="418" alt="uuid" src="https://user-images.githubusercontent.com/26461464/82950513-b7c85080-9fa5-11ea-8215-0f5c50292404.png">
I find it more convenient. What do you think about it ?
