### PR TITLE
Fix #327 DeviceUtils doesn't list all mount points

### DIFF
--- a/driver/src/main/java/studio/driver/fs/DeviceUtils.java
+++ b/driver/src/main/java/studio/driver/fs/DeviceUtils.java
@@ -32,8 +32,8 @@ public class DeviceUtils {
                     .map(root -> root.toPath().toString())
                     .collect(Collectors.toList());
         } else {
-            final String CMD_DF = "df -l";
-            final Pattern dfPattern = Pattern.compile("^(\\/[^ ]+)[^/]+(/.*)$");
+            final String CMD_DF = SystemUtils.IS_OS_MAC ? "df" : "df -l";
+            final Pattern dfPattern = Pattern.compile("^([^ ]+)[^/]+(/.*)$");
 
             List<String> mountPoints = new ArrayList<>();
 
@@ -51,7 +51,7 @@ public class DeviceUtils {
                     if (matcher.matches()) {
                         final String dev = matcher.group(1);
                         final String rootPath = matcher.group(2);
-                        if (dev.startsWith("/dev/")) {
+                        if (dev.startsWith("/dev/") || SystemUtils.IS_OS_MAC) {
                             mountPoints.add(rootPath);
                         }
                     }


### PR DESCRIPTION
On macOS Ventura, "df -l" doesn't list all mount points and device name doesn't always start with with "/dev/".