### PR TITLE
Cache Library packs to speed up UI thread

### DIFF
--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>log4j-jul</artifactId>
             <version>2.13.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Library packs are read in the UI thread and with a large number of packs in the library, this causes extra delays and even exceeds vert.x thread timeout.

While a better design would be to build the library on startup, and rely on filesystem watches to keep it updated (and avoid doing these in the UI thread), this introduces  a cache so that library packs read from disks are not re-read from disk for nothing. This results into a snappier experience both when accessing the library for the first time, and also on later refreshs.