### PR TITLE
Add support to M1 silicon by importing correct libusb4java version

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -19,6 +19,10 @@
 
     <packaging>jar</packaging>
 
+    <properties>
+        <usb4java.version>1.3.0</usb4java.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>studio</groupId>
@@ -28,7 +32,7 @@
         <dependency>
             <groupId>org.usb4java</groupId>
             <artifactId>usb4java</artifactId>
-            <version>1.3.0</version>
+            <version>${usb4java.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -39,6 +43,48 @@
             <artifactId>commons-io</artifactId>
         </dependency>
     </dependencies>
+
+    <!--
+        Platform-specific native library dependencies.
+        Profiles ensure only the correct architecture library is included,
+        preventing conflicts and reducing JAR size.
+    -->
+    <profiles>
+        <profile>
+            <id>darwin-aarch64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <!-- Third-party artifact for Apple Silicon support -->
+                <dependency>
+                    <groupId>io.github.dsheirer</groupId>
+                    <artifactId>libusb4java-darwin-aarch64</artifactId>
+                    <version>${usb4java.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>darwin-x86-64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.usb4java</groupId>
+                    <artifactId>libusb4java</artifactId>
+                    <version>${usb4java.version}</version>
+                    <classifier>darwin-x86-64</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 
 </project>

--- a/web-ui/javascript/yarn.lock
+++ b/web-ui/javascript/yarn.lock
@@ -2885,9 +2885,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000939, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001061:
-  version "1.0.30001662"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz"
-  integrity sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==
+  version "1.0.30001760"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz"
+  integrity sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/web-ui/src/main/resources/studio-macos.sh
+++ b/web-ui/src/main/resources/studio-macos.sh
@@ -12,4 +12,30 @@ if [ ! -d $DOT_STUDIO/library ]; then mkdir -p $DOT_STUDIO/library; fi
 cp $STUDIO_PATH/agent/studio-agent-${project.version}-jar-with-dependencies.jar $DOT_STUDIO/agent/studio-agent.jar
 cp $STUDIO_PATH/agent/studio-metadata-${project.version}-jar-with-dependencies.jar $DOT_STUDIO/agent/studio-metadata.jar
 
+# Configure libusb library path for libusb4java
+# The library expects libusb at /opt/local/lib (MacPorts), but Homebrew installs it elsewhere
+LIBUSB_TARGET="/opt/local/lib/libusb-1.0.0.dylib"
+LIBUSB_SOURCE=""
+
+# Check if MacPorts libusb already exists (no action needed)
+if [ -f "$LIBUSB_TARGET" ]; then
+    : # Already exists, nothing to do
+# Check for Homebrew libusb (Apple Silicon: /opt/homebrew, Intel: /usr/local)
+elif [ -f "/opt/homebrew/lib/libusb-1.0.dylib" ]; then
+    LIBUSB_SOURCE="/opt/homebrew/lib/libusb-1.0.dylib"
+elif [ -f "/usr/local/lib/libusb-1.0.dylib" ]; then
+    LIBUSB_SOURCE="/usr/local/lib/libusb-1.0.dylib"
+fi
+
+# Create symlink if needed
+if [ -n "$LIBUSB_SOURCE" ]; then
+    if mkdir -p /opt/local/lib 2>/dev/null && ln -sf "$LIBUSB_SOURCE" "$LIBUSB_TARGET" 2>/dev/null; then
+        : # Symlink created successfully
+    else
+        # Fallback: use DYLD_FALLBACK_LIBRARY_PATH (may not work on all macOS versions due to SIP)
+        LIBUSB_DIR=$(dirname "$LIBUSB_SOURCE")
+        export DYLD_FALLBACK_LIBRARY_PATH="$LIBUSB_DIR:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+    fi
+fi
+
 java -Dvertx.disableDnsResolver=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -Dfile.encoding=UTF-8 -cp $STUDIO_PATH/${project.build.finalName}.jar:$STUDIO_PATH/lib/*:. io.vertx.core.Launcher run ${vertx.main.verticle}


### PR DESCRIPTION
I added a way for M1 silicon from Apple to be supported by this code base. 
- Pulling the correct libusb depending on if it is an intel processor or a apple processor

works locally
<img width="1414" height="102" alt="image" src="https://github.com/user-attachments/assets/ec53d442-f702-43d1-aad8-2c8a9abf2a13" />


another user reported it not working [here](https://github.com/marian-m12l/studio/issues/531)