### PR TITLE
Fix slow library loading and repeated blocked-thread warnings

### DIFF
--- a/core/src/main/java/studio/core/v1/reader/archive/ArchiveStoryPackReader.java
+++ b/core/src/main/java/studio/core/v1/reader/archive/ArchiveStoryPackReader.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.io.IOUtils;
 import studio.core.v1.Constants;
 import studio.core.v1.model.*;
@@ -20,12 +21,59 @@ import studio.core.v1.model.enriched.EnrichedNodeType;
 import studio.core.v1.model.enriched.EnrichedPackMetadata;
 import studio.core.v1.model.metadata.StoryPackMetadata;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.*;
 
 public class ArchiveStoryPackReader {
+
+    // Random-access read of only the entries needed for metadata (story.json, thumbnail.png), using the zip's
+    // central directory. This avoids inflating every asset entry just to skip over it, which
+    // ZipArchiveInputStream's sequential/streaming API would otherwise require.
+    public StoryPackMetadata readMetadata(File file) throws IOException {
+        StoryPackMetadata metadata = new StoryPackMetadata(Constants.PACK_FORMAT_ARCHIVE);
+        boolean hasStoryJsonEntry = false;
+
+        try (ZipFile zipFile = new ZipFile(file)) {
+            Enumeration<ZipArchiveEntry> entries = zipFile.getEntries();
+            while (entries.hasMoreElements()) {
+                ZipArchiveEntry entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                if (entry.getName().equalsIgnoreCase("story.json")) {
+                    hasStoryJsonEntry = true;
+                    try (InputStream is = zipFile.getInputStream(entry)) {
+                        JsonObject root = new JsonParser().parse(new InputStreamReader(is)).getAsJsonObject();
+
+                        // Read metadata
+                        metadata.setVersion(root.get("version").getAsShort());
+                        Optional.ofNullable(root.get("title")).filter(JsonElement::isJsonPrimitive).ifPresent(title ->
+                                metadata.setTitle(title.getAsString())
+                        );
+                        Optional.ofNullable(root.get("description")).filter(JsonElement::isJsonPrimitive).ifPresent(desc ->
+                                metadata.setDescription(desc.getAsString())
+                        );
+
+                        // Night mode
+                        metadata.setNightModeAvailable(Optional.ofNullable(root.get("nightModeAvailable")).map(JsonElement::getAsBoolean).orElse(false));
+
+                        // Read first stage node
+                        JsonObject mainStageNode = root.getAsJsonArray("stageNodes").get(0).getAsJsonObject();
+                        metadata.setUuid(mainStageNode.get("uuid").getAsString());
+                    }
+                } else if (entry.getName().equalsIgnoreCase("thumbnail.png")) {
+                    try (InputStream is = zipFile.getInputStream(entry)) {
+                        metadata.setThumbnail(IOUtils.toByteArray(is));
+                    }
+                }
+            }
+        }
+
+        return hasStoryJsonEntry ? metadata : null;
+    }
 
     public StoryPackMetadata readMetadata(InputStream inputStream) throws IOException {
         // Zip archive contains a json file and separate assets

--- a/metadata/src/main/java/studio/metadata/DatabaseMetadataService.java
+++ b/metadata/src/main/java/studio/metadata/DatabaseMetadataService.java
@@ -30,6 +30,7 @@ public class DatabaseMetadataService {
     public static final String UNOFFICIAL_DB_JSON_PATH = "/.studio/db/unofficial.json";
 
     private final Map<String, JsonObject> cachedOfficialDatabase;
+    private JsonObject cachedUnofficialDatabase;
 
     public DatabaseMetadataService(boolean isAgent) {
         // Read and cache official database
@@ -72,9 +73,22 @@ public class DatabaseMetadataService {
                 LOGGER.log(Level.SEVERE, "Failed to initialize unofficial metadata database", e);
                 throw new IllegalStateException("Failed to initialize unofficial metadata database");
             }
-        } else if (!isAgent) {
-            // Otherwise clear unofficial database from official packs metadata
+        }
+        // Read and cache unofficial database, to avoid re-reading/re-parsing this (potentially large) file on every access
+        LOGGER.fine("Reading and caching unofficial metadata database");
+        this.cachedUnofficialDatabase = readUnofficialDatabaseFromDisk(databasePath);
+        if (!isAgent) {
+            // Clear unofficial database from official packs metadata
             this.cleanUnofficialDatabase();
+        }
+    }
+
+    private JsonObject readUnofficialDatabaseFromDisk(String databasePath) {
+        try {
+            return new JsonParser().parse(new FileReader(databasePath)).getAsJsonObject();
+        } catch (FileNotFoundException e) {
+            LOGGER.log(Level.SEVERE, "Missing unofficial metadata database file", e);
+            return new JsonObject();
         }
     }
 
@@ -111,22 +125,16 @@ public class DatabaseMetadataService {
 
     public synchronized Optional<DatabasePackMetadata> getUnofficialMetadata(String uuid) {
         LOGGER.fine("Fetching metadata from unofficial database for pack: " + uuid);
-        // Fetch from unofficial metadata database file (path may be overridden by system property `studio.db.unofficial`)
-        try {
-            String databasePath = System.getProperty(UNOFFICIAL_DB_PROP, System.getProperty("user.home") + UNOFFICIAL_DB_JSON_PATH);
-            JsonObject unofficialRoot = new JsonParser().parse(new FileReader(databasePath)).getAsJsonObject();
-            if (unofficialRoot.has(uuid)) {
-                JsonObject packMetadata = unofficialRoot.getAsJsonObject(uuid);
-                return Optional.of(new DatabasePackMetadata(
-                        uuid,
-                        Optional.ofNullable(packMetadata.get("title")).map(JsonElement::getAsString).orElse(null),
-                        Optional.ofNullable(packMetadata.get("description")).map(JsonElement::getAsString).orElse(null),
-                        Optional.ofNullable(packMetadata.get("image")).map(JsonElement::getAsString).orElse(null),
-                        false
-                ));
-            }
-        } catch (FileNotFoundException e) {
-            LOGGER.log(Level.SEVERE, "Missing unofficial metadata database file", e);
+        // Fetch from cached unofficial metadata database
+        if (cachedUnofficialDatabase.has(uuid)) {
+            JsonObject packMetadata = cachedUnofficialDatabase.getAsJsonObject(uuid);
+            return Optional.of(new DatabasePackMetadata(
+                    uuid,
+                    Optional.ofNullable(packMetadata.get("title")).map(JsonElement::getAsString).orElse(null),
+                    Optional.ofNullable(packMetadata.get("description")).map(JsonElement::getAsString).orElse(null),
+                    Optional.ofNullable(packMetadata.get("image")).map(JsonElement::getAsString).orElse(null),
+                    false
+            ));
         }
 
         // Missing metadata
@@ -203,60 +211,59 @@ public class DatabaseMetadataService {
         }
     }
 
-    public void refreshUnofficialMetadata(DatabasePackMetadata meta) {
+    public synchronized void refreshUnofficialMetadata(DatabasePackMetadata meta) {
         // Refresh unofficial database only if the pack isn't an official one
         if (this.getOfficialMetadata(meta.getUuid()).isPresent()) {
             return;
         }
-        // Update unofficial database
+        // Replace or add pack metadata
+        JsonObject value = new JsonObject();
+        value.addProperty("uuid", meta.getUuid());
+        if (meta.getTitle() != null) {
+            value.addProperty("title", meta.getTitle());
+        }
+        if (meta.getDescription() != null) {
+            value.addProperty("description", meta.getDescription());
+        }
+        if (meta.getThumbnail() != null) {
+            value.addProperty("image", meta.getThumbnail());
+        }
+
+        // Skip disk write if metadata is unchanged, to avoid rewriting the whole (potentially large) database file needlessly
+        if (value.equals(cachedUnofficialDatabase.get(meta.getUuid()))) {
+            return;
+        }
+        cachedUnofficialDatabase.add(meta.getUuid(), value);
+
+        // Write database file
         try {
-            // Open database file
             String databasePath = System.getProperty(UNOFFICIAL_DB_PROP, System.getProperty("user.home") + UNOFFICIAL_DB_JSON_PATH);
-            JsonObject unofficialRoot = new JsonParser().parse(new FileReader(databasePath)).getAsJsonObject();
-
-            // Replace or add pack metadata
-            JsonObject value = new JsonObject();
-            value.addProperty("uuid", meta.getUuid());
-            if (meta.getTitle() != null) {
-                value.addProperty("title", meta.getTitle());
-            }
-            if (meta.getDescription() != null) {
-                value.addProperty("description", meta.getDescription());
-            }
-            if (meta.getThumbnail() != null) {
-                value.addProperty("image", meta.getThumbnail());
-            }
-            unofficialRoot.add(meta.getUuid(), value);
-
-            // Write database file
-            writeDatabaseFile(databasePath, unofficialRoot);
-        } catch (FileNotFoundException e) {
-            LOGGER.log(Level.SEVERE, "Missing unofficial metadata database file", e);
+            writeDatabaseFile(databasePath, cachedUnofficialDatabase);
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Failed to update unofficial metadata database file", e);
         }
     }
 
-    public void cleanUnofficialDatabase() {
+    public synchronized void cleanUnofficialDatabase() {
         LOGGER.fine("Cleaning unofficial database.");
-        // Remove official packs from unofficial metadata database file
+        // Remove official packs from cached unofficial metadata database
+        List<String> toClean = new ArrayList<>();
+        for (String uuid : cachedUnofficialDatabase.keySet()) {
+            if (this.isOfficialPack(uuid)) {
+                toClean.add(uuid);
+            }
+        }
+        if (toClean.isEmpty()) {
+            return;
+        }
+        for (String uuid : toClean) {
+            cachedUnofficialDatabase.remove(uuid);
+        }
+
+        // Write database file
         try {
             String databasePath = System.getProperty(UNOFFICIAL_DB_PROP, System.getProperty("user.home") + UNOFFICIAL_DB_JSON_PATH);
-            JsonObject unofficialRoot = new JsonParser().parse(new FileReader(databasePath)).getAsJsonObject();
-            List<String> toClean = new ArrayList<>();
-            for (String uuid : unofficialRoot.keySet()) {
-                if (this.isOfficialPack(uuid)) {
-                    toClean.add(uuid);
-                }
-            }
-            for (String uuid : toClean) {
-                unofficialRoot.remove(uuid);
-            }
-
-            // Write database file
-            writeDatabaseFile(databasePath, unofficialRoot);
-        } catch (FileNotFoundException e) {
-            LOGGER.log(Level.SEVERE, "Missing unofficial metadata database file", e);
+            writeDatabaseFile(databasePath, cachedUnofficialDatabase);
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Failed to clean unofficial metadata database file", e);
         }

--- a/web-ui/src/main/java/studio/webui/service/LibraryService.java
+++ b/web-ui/src/main/java/studio/webui/service/LibraryService.java
@@ -106,7 +106,7 @@ public class LibraryService {
                             List<LibraryPack> packs = entry.getValue();
                             packs.sort((a, b) -> Long.compare(b.getTimestamp(), a.getTimestamp()));
                             LOGGER.debug("Refreshing metadata for pack `" + entry.getKey() + "` from file `" + packs.get(0).getPath() + "`");
-                            this.readPackFile(packs.get(0).getPath()).ifPresent(
+                            cachedPacks.get(packs.get(0).getPath(), this::readPackFile).ifPresent(
                                     meta -> databaseMetadataService.refreshUnofficialMetadata(
                                             new DatabasePackMetadata(
                                                     meta.getMetadata().getUuid(),
@@ -434,10 +434,10 @@ public class LibraryService {
         LOGGER.debug("Reading pack file: " + path.toString());
         // Handle all file formats
         if (path.toString().endsWith(".zip")) {
-            try (FileInputStream fis = new FileInputStream(path.toFile())) {
+            try {
                 LOGGER.debug("Reading archive pack metadata.");
                 ArchiveStoryPackReader packReader = new ArchiveStoryPackReader();
-                StoryPackMetadata meta = packReader.readMetadata(fis);
+                StoryPackMetadata meta = packReader.readMetadata(path.toFile());
                 if (meta != null) {
                     return Optional.of(new LibraryPack(path, Files.getLastModifiedTime(path).toMillis() , meta));
                 }


### PR DESCRIPTION
## Summary

The local library screen could take minutes to load and spam the console with `io.vertx.core.VertxException: Thread blocked` warnings when the library contained many packs, especially with a large unofficial metadata database.

Three compounding issues in the `packs()` request path:

- `DatabaseMetadataService` re-read and re-parsed the entire unofficial metadata database file from disk on every single pack lookup, and rewrote the whole file on every refresh, instead of caching it in memory like the official database already was.
- `LibraryService.packs()` read the most recent pack file of every group a second time to refresh its metadata, bypassing the existing short-lived pack cache and duplicating disk reads.
- `ArchiveStoryPackReader.readMetadata` used a sequential zip stream, which has to inflate every asset entry just to skip past it, even though only `story.json` and `thumbnail.png` are needed. Switched to random-access reads via the zip's central directory.

Fixes #603

## Test plan

Verified against a real local library (249 pack files, ~46 unofficial database entries, 18.5 MB `unofficial.json`) by building the full distribution and measuring `GET /api/library/packs`:

- [x] Before: repeated `Thread blocked` warnings (60s-260s+ per block), library load in the multiple-minutes range
- [x] After: cold load ~3.4s with zero blocked-thread warnings, cached reload ~0.3s
- [x] Full `mvn clean install` build passes