### PR TITLE
Queue device transfers instead of rejecting them when busy

### DIFF
--- a/web-ui/javascript/src/actions/index.js
+++ b/web-ui/javascript/src/actions/index.js
@@ -143,8 +143,10 @@ export const actionRefreshDevice = (t) => {
                     });
             },
             e => {
-                // Device is busy
-                toast.error(t('toasts.device.busy'));
+                // Device is busy: this refresh is called automatically after every queued
+                // transfer, so it routinely loses the race against the next queued transfer.
+                // Skip silently -- the refresh after the last queued transfer will still run.
+                console.log('device busy, skipping automatic refresh');
             });
 };
 

--- a/web-ui/javascript/src/actions/index.js
+++ b/web-ui/javascript/src/actions/index.js
@@ -18,7 +18,17 @@ import {readFromArchive} from "../utils/reader";
 import {simplifiedSample} from "../utils/sample";
 
 
-const mutex = withTimeout(new Mutex(), 100);
+// Single mutex serializes all device (USB) operations. Quick status checks use the
+// timed-out `mutex` view so they fail fast if busy; transfer operations use the raw
+// `deviceMutex` directly so they queue up (FIFO) instead of being rejected outright.
+const deviceMutex = new Mutex();
+const mutex = withTimeout(deviceMutex, 100);
+
+// Bytes reserved by transfers that are queued or in progress towards the device, but not
+// yet reflected in the device's reported `taken`/`free` storage (which only updates after
+// a transfer completes and the device is refreshed). Used to avoid over-committing the
+// device's remaining space when several transfers are queued up.
+let reservedDeviceBytes = 0;
 
 export const actionLoadLibrary = (t) => {
     return dispatch => {
@@ -138,63 +148,81 @@ export const actionRefreshDevice = (t) => {
             });
 };
 
-export const actionAddFromLibrary = (uuid, path, format, driver, context, t) => {
-    return dispatch => mutex.acquire()
-        .then(
-            release => {
-                // First, make sure the story pack is in the right format.
-                if (driver !== format) {
-                    console.error('pack format is not compatible with the device');
-                    toast.error(t('toasts.device.notCompatible'));
-                    // Always release the mutex
+export const actionAddFromLibrary = (uuid, path, format, driver, sizeInBytes, context, t) => {
+    return (dispatch, getState) => {
+        // First, make sure the story pack is in the right format.
+        if (driver !== format) {
+            console.error('pack format is not compatible with the device');
+            toast.error(t('toasts.device.notCompatible'));
+            return Promise.resolve();
+        }
+        // Check estimated available space on the device before queueing the transfer, accounting
+        // for transfers that are already queued/in progress but not yet reflected in device storage infos
+        const deviceMetadata = getState().device.metadata;
+        if (sizeInBytes != null && deviceMetadata) {
+            let estimatedAvailable = deviceMetadata.storage.free - reservedDeviceBytes;
+            if (sizeInBytes > estimatedAvailable) {
+                console.error('not enough estimated space on device for this transfer');
+                toast.error(t('toasts.device.notEnoughSpace'));
+                return Promise.resolve();
+            }
+            reservedDeviceBytes += sizeInBytes;
+        }
+        // Queue the transfer: it starts as soon as any previous device operation is done
+        let queued = deviceMutex.isLocked();
+        let toastId = toast(t(queued ? 'toasts.device.queued' : 'toasts.device.adding'), { autoClose: false });
+        return deviceMutex.acquire()
+            .then(release => {
+                const releaseAll = () => {
+                    if (sizeInBytes != null) {
+                        reservedDeviceBytes -= sizeInBytes;
+                    }
                     release();
-                } else {
-                    // Then start transfer
-                    let toastId = toast(t('toasts.device.adding'), { autoClose: false });
-                    return addFromLibrary(uuid, path)
-                        .then(resp => {
-                            // Monitor transfer progress
-                            let transferId = resp.transferId;
-                            context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.progress', (error, message) => {
-                                console.log("Received `storyteller.transfer."+transferId+".progress` event from vert.x event bus.");
-                                console.log(message.body);
-                                if (message.body.progress < 1) {
-                                    toast.update(toastId, {progress: message.body.progress, autoClose: false});
-                                }
-                            });
-                            context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.done', (error, message) => {
-                                console.log("Received `storyteller.transfer."+transferId+".done` event from vert.x event bus.");
-                                console.log(message.body);
-                                if (message.body.success) {
-                                    toast.update(toastId, {progress: null, type: toast.TYPE.SUCCESS, render: t('toasts.device.added'), autoClose: 5000});
-                                    // Refresh device metadata and packs list
-                                    dispatch(actionRefreshDevice(t));
-                                } else {
-                                    toast.update(toastId, {progress: null, type: toast.TYPE.ERROR, render: <IssueReportToast content={<>{t('toasts.device.addingFailed')}</>} />, autoClose: false });
-                                }
-                                // Always release the mutex
-                                release();
-                            });
-                        })
-                        .catch(e => {
-                            console.error('failed to add pack to device', e);
-                            toast.update(toastId, { type: toast.TYPE.ERROR, render: <IssueReportToast content={<>{t('toasts.device.addingFailed')}</>} error={e} />, autoClose: false });
-                            // Always release the mutex
-                            release();
+                };
+                // Start transfer
+                toast.update(toastId, { render: t('toasts.device.adding') });
+                return addFromLibrary(uuid, path)
+                    .then(resp => {
+                        // Monitor transfer progress
+                        let transferId = resp.transferId;
+                        context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.progress', (error, message) => {
+                            console.log("Received `storyteller.transfer."+transferId+".progress` event from vert.x event bus.");
+                            console.log(message.body);
+                            if (message.body.progress < 1) {
+                                toast.update(toastId, {progress: message.body.progress, autoClose: false});
+                            }
                         });
-                }
-            },
-            e => {
-                // Device is busy
-                toast.error(t('toasts.device.busy'));
+                        context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.done', (error, message) => {
+                            console.log("Received `storyteller.transfer."+transferId+".done` event from vert.x event bus.");
+                            console.log(message.body);
+                            if (message.body.success) {
+                                toast.update(toastId, {progress: null, type: toast.TYPE.SUCCESS, render: t('toasts.device.added'), autoClose: 5000});
+                                // Refresh device metadata and packs list
+                                dispatch(actionRefreshDevice(t));
+                            } else {
+                                toast.update(toastId, {progress: null, type: toast.TYPE.ERROR, render: <IssueReportToast content={<>{t('toasts.device.addingFailed')}</>} />, autoClose: false });
+                            }
+                            // Always release the reservation and the mutex
+                            releaseAll();
+                        });
+                    })
+                    .catch(e => {
+                        console.error('failed to add pack to device', e);
+                        toast.update(toastId, { type: toast.TYPE.ERROR, render: <IssueReportToast content={<>{t('toasts.device.addingFailed')}</>} error={e} />, autoClose: false });
+                        // Always release the reservation and the mutex
+                        releaseAll();
+                    });
             });
+    };
 };
 
 export const actionRemoveFromDevice = (uuid, t) => {
-    return dispatch => mutex.acquire()
-        .then(
-            release => {
-                let toastId = toast(t('toasts.device.removing'), { autoClose: false });
+    return dispatch => {
+        let queued = deviceMutex.isLocked();
+        let toastId = toast(t(queued ? 'toasts.device.queued' : 'toasts.device.removing'), { autoClose: false });
+        return deviceMutex.acquire()
+            .then(release => {
+                toast.update(toastId, { render: t('toasts.device.removing') });
                 return removeFromDevice(uuid)
                     .then(resp => {
                         if (resp.success) {
@@ -213,18 +241,17 @@ export const actionRemoveFromDevice = (uuid, t) => {
                         // Always release the mutex
                         release();
                     });
-            },
-            e => {
-                // Device is busy
-                toast.error(t('toasts.device.busy'));
             });
+    };
 };
 
 export const actionReorderOnDevice = (uuids, t) => {
-    return dispatch => mutex.acquire()
-        .then(
-            release => {
-                let toastId = toast(t('toasts.device.reordering'), { autoClose: false });
+    return dispatch => {
+        let queued = deviceMutex.isLocked();
+        let toastId = toast(t(queued ? 'toasts.device.queued' : 'toasts.device.reordering'), { autoClose: false });
+        return deviceMutex.acquire()
+            .then(release => {
+                toast.update(toastId, { render: t('toasts.device.reordering') });
                 return reorderPacks(uuids)
                     .then(resp => {
                         if (resp.success) {
@@ -243,18 +270,17 @@ export const actionReorderOnDevice = (uuids, t) => {
                         // Always release the mutex
                         release();
                     });
-            },
-            e => {
-                // Device is busy
-                toast.error(t('toasts.device.busy'));
             });
+    };
 };
 
 export const actionAddToLibrary = (uuid, driver, context, t) => {
-    return dispatch => mutex.acquire()
-        .then(
-            release => {
-                let toastId = toast(t('toasts.library.adding'), { autoClose: false });
+    return dispatch => {
+        let queued = deviceMutex.isLocked();
+        let toastId = toast(t(queued ? 'toasts.device.queued' : 'toasts.library.adding'), { autoClose: false });
+        return deviceMutex.acquire()
+            .then(release => {
+                toast.update(toastId, { render: t('toasts.library.adding') });
                 return addToLibrary(uuid, driver)
                     .then(resp => {
                         // Monitor transfer progress
@@ -286,11 +312,8 @@ export const actionAddToLibrary = (uuid, driver, context, t) => {
                         // Always release the mutex
                         release();
                     });
-            },
-            e => {
-                // Device is busy
-                toast.error(t('toasts.device.busy'));
             });
+    };
 };
 
 export const actionRefreshLibrary = (t) => {
@@ -431,7 +454,7 @@ export const actionConvertInLibrary = (uuid, path, format, allowEnriched, contex
                     });
                     // Refresh device metadata and packs list
                     dispatch(actionRefreshLibrary(t));
-                    return resp.path;
+                    return { path: resp.path, sizeInBytes: resp.sizeInBytes };
                 } else {
                     toast.update(toastId, { type: toast.TYPE.ERROR, render: <IssueReportToast content={<>{t('toasts.library.convertingFailed')}</>} />, autoClose: false });
                 }

--- a/web-ui/javascript/src/actions/index.js
+++ b/web-ui/javascript/src/actions/index.js
@@ -30,6 +30,51 @@ const mutex = withTimeout(deviceMutex, 100);
 // device's remaining space when several transfers are queued up.
 let reservedDeviceBytes = 0;
 
+// If nothing is heard for a transfer (no progress, no completion) for this long, treat it as
+// failed rather than waiting forever.
+const STALLED_TRANSFER_TIMEOUT_MS = 60000;
+
+// Registers progress/done handlers for a transfer over the event bus, with a stall-timeout
+// safety net. The `done` event has been observed to never reach the client when the device
+// disconnects mid-transfer (the same disconnect that fails the transfer server-side appears to
+// sometimes also disrupt delivery of its own completion event) -- without this, the caller
+// (and the device operation queue behind it) would wait forever. `onSettled(success)` is
+// called exactly once, either from a real `done` event or from the stall timeout.
+const watchTransfer = (transferId, context, toastId, onSettled) => {
+    let settled = false;
+    let timeoutId;
+    const settle = (success) => {
+        if (settled) {
+            return;
+        }
+        settled = true;
+        clearTimeout(timeoutId);
+        onSettled(success);
+    };
+    const scheduleStallTimeout = () => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+            console.error('Timed out waiting for completion of transfer: ' + transferId);
+            settle(false);
+        }, STALLED_TRANSFER_TIMEOUT_MS);
+    };
+    scheduleStallTimeout();
+    context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.progress', (error, message) => {
+        console.log("Received `storyteller.transfer."+transferId+".progress` event from vert.x event bus.");
+        console.log(message.body);
+        // Any sign of life resets the stall timeout
+        scheduleStallTimeout();
+        if (message.body.progress < 1) {
+            toast.update(toastId, {progress: message.body.progress, autoClose: false});
+        }
+    });
+    context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.done', (error, message) => {
+        console.log("Received `storyteller.transfer."+transferId+".done` event from vert.x event bus.");
+        console.log(message.body);
+        settle(!!(message.body && message.body.success));
+    });
+};
+
 export const actionLoadLibrary = (t) => {
     return dispatch => {
         let toastId = toast(t('toasts.library.loading'), { autoClose: false });
@@ -185,25 +230,15 @@ export const actionAddFromLibrary = (uuid, path, format, driver, sizeInBytes, co
                 toast.update(toastId, { render: t('toasts.device.adding') });
                 return addFromLibrary(uuid, path)
                     .then(resp => {
-                        // Monitor transfer progress
-                        let transferId = resp.transferId;
-                        context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.progress', (error, message) => {
-                            console.log("Received `storyteller.transfer."+transferId+".progress` event from vert.x event bus.");
-                            console.log(message.body);
-                            if (message.body.progress < 1) {
-                                toast.update(toastId, {progress: message.body.progress, autoClose: false});
-                            }
-                        });
-                        context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.done', (error, message) => {
-                            console.log("Received `storyteller.transfer."+transferId+".done` event from vert.x event bus.");
-                            console.log(message.body);
-                            if (message.body.success) {
+                        watchTransfer(resp.transferId, context, toastId, success => {
+                            if (success) {
                                 toast.update(toastId, {progress: null, type: toast.TYPE.SUCCESS, render: t('toasts.device.added'), autoClose: 5000});
-                                // Refresh device metadata and packs list
-                                dispatch(actionRefreshDevice(t));
                             } else {
                                 toast.update(toastId, {progress: null, type: toast.TYPE.ERROR, render: <IssueReportToast content={<>{t('toasts.device.addingFailed')}</>} />, autoClose: false });
                             }
+                            // Refresh either way: on a stalled/lost completion event we don't actually
+                            // know whether the transfer went through on the device, so reflect reality.
+                            dispatch(actionRefreshDevice(t));
                             // Always release the reservation and the mutex
                             releaseAll();
                         });
@@ -285,25 +320,15 @@ export const actionAddToLibrary = (uuid, driver, context, t) => {
                 toast.update(toastId, { render: t('toasts.library.adding') });
                 return addToLibrary(uuid, driver)
                     .then(resp => {
-                        // Monitor transfer progress
-                        let transferId = resp.transferId;
-                        context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.progress', (error, message) => {
-                            console.log("Received `storyteller.transfer."+transferId+".progress` event from vert.x event bus.");
-                            console.log(message.body);
-                            if (message.body.progress < 1) {
-                                toast.update(toastId, {progress: message.body.progress, autoClose: false});
-                            }
-                        });
-                        context.eventBus.registerHandler('storyteller.transfer.'+transferId+'.done', (error, message) => {
-                            console.log("Received `storyteller.transfer."+transferId+".done` event from vert.x event bus.");
-                            console.log(message.body);
-                            if (message.body.success) {
+                        watchTransfer(resp.transferId, context, toastId, success => {
+                            if (success) {
                                 toast.update(toastId, {progress: null, type: toast.TYPE.SUCCESS, render: t('toasts.library.added'), autoClose: 5000});
-                                // Refresh device metadata and packs list
-                                dispatch(actionRefreshLibrary(t));
                             } else {
                                 toast.update(toastId, {progress: null, type: toast.TYPE.ERROR, render: <IssueReportToast content={<>{t('toasts.library.addingFailed')}</>} />, autoClose: false });
                             }
+                            // Refresh either way: on a stalled/lost completion event we don't actually
+                            // know whether the transfer went through, so reflect reality.
+                            dispatch(actionRefreshLibrary(t));
                             // Always release the mutex
                             release();
                         });

--- a/web-ui/javascript/src/components/PackLibrary.js
+++ b/web-ui/javascript/src/components/PackLibrary.js
@@ -107,8 +107,8 @@ class PackLibrary extends React.Component {
             } else {
                 // Pack is converted and stored in the local library, then transferred to the device
                 this.props.convertPackInLibrary(latestPack.uuid, latestPack.path, this.state.device.metadata.driver, this.props.settings.allowEnriched, this.context)
-                    .then(path => {
-                        this.doAddToDevice({...latestPack, format: this.state.device.metadata.driver}, path);
+                    .then(({path, sizeInBytes}) => {
+                        this.doAddToDevice({...latestPack, format: this.state.device.metadata.driver, sizeInBytes}, path);
                     });
             }
         } else if (latestPack.timestamp > compatiblePack.timestamp) {   // Compatible pack is not the latest pack: confirm re-conversion
@@ -129,7 +129,7 @@ class PackLibrary extends React.Component {
 
     doAddToDevice = (data, path) => {
         // Transfer pack and show progress
-        this.props.addFromLibrary(data.uuid, path, data.format, this.state.device.metadata.driver, this.context);
+        this.props.addFromLibrary(data.uuid, path, data.format, this.state.device.metadata.driver, data.sizeInBytes, this.context);
     };
 
     dismissEnrichedDialog = (allow) => {
@@ -137,9 +137,9 @@ class PackLibrary extends React.Component {
             this.props.setAllowEnriched(allow);
             // Pack is converted and stored in the local library, then transferred to the device
             this.props.convertPackInLibrary(this.state.allowEnrichedDialog.data.pack.uuid, this.state.allowEnrichedDialog.data.pack.path, this.state.allowEnrichedDialog.data.format, allow, this.context)
-                .then(path => {
+                .then(({path, sizeInBytes}) => {
                     if (this.state.allowEnrichedDialog.data.addToDevice) {
-                        return this.doAddToDevice(this.state.allowEnrichedDialog.data.pack, path);
+                        return this.doAddToDevice({...this.state.allowEnrichedDialog.data.pack, sizeInBytes}, path);
                     }
                 })
                 .then(() => {
@@ -158,7 +158,7 @@ class PackLibrary extends React.Component {
             if (answer) {
                 // Pack is converted and stored in the local library, then transferred to the device
                 this.props.convertPackInLibrary(this.state.confirmConversionDialog.data.pack.uuid, this.state.confirmConversionDialog.data.pack.path, this.state.confirmConversionDialog.data.format, this.props.settings.allowEnriched, this.context)
-                    .then(path => this.doAddToDevice(this.state.confirmConversionDialog.data.pack, path))
+                    .then(({path, sizeInBytes}) => this.doAddToDevice({...this.state.confirmConversionDialog.data.pack, sizeInBytes}, path))
                     .then(() => {
                         this.setState({
                             confirmConversionDialog: {
@@ -573,7 +573,7 @@ const mapStateToProps = (state, ownProps) => ({
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-    addFromLibrary: (uuid, path, format, driver, context) => dispatch(actionAddFromLibrary(uuid, path, format, driver, context, ownProps.t)),
+    addFromLibrary: (uuid, path, format, driver, sizeInBytes, context) => dispatch(actionAddFromLibrary(uuid, path, format, driver, sizeInBytes, context, ownProps.t)),
     removeFromDevice: (uuid) => dispatch(actionRemoveFromDevice(uuid, ownProps.t)),
     reorderOnDevice: (uuids) => dispatch(actionReorderOnDevice(uuids, ownProps.t)),
     addToLibrary: (uuid, driver, context) => dispatch(actionAddToLibrary(uuid, driver, context, ownProps.t)),

--- a/web-ui/src/main/java/studio/webui/api/LibraryController.java
+++ b/web-ui/src/main/java/studio/webui/api/LibraryController.java
@@ -124,12 +124,14 @@ public class LibraryController {
             }
             futureConvertedPack.onComplete(maybeConvertedPack -> {
                 if (maybeConvertedPack.succeeded()) {
-                    // Return path to converted file within library
+                    // Return path to converted file within library, along with its size on disk
+                    String convertedPath = maybeConvertedPack.result().toString();
                     ctx.response()
                             .putHeader("content-type", "application/json")
                             .end(Json.encode(new JsonObject()
                                     .put("success", true)
-                                    .put("path", maybeConvertedPack.result().toString())
+                                    .put("path", convertedPath)
+                                    .put("sizeInBytes", libraryService.packSizeInBytes(convertedPath))
                             ));
                 } else {
                     LOGGER.error("Failed to read or convert pack");

--- a/web-ui/src/main/java/studio/webui/service/LibraryService.java
+++ b/web-ui/src/main/java/studio/webui/service/LibraryService.java
@@ -492,6 +492,7 @@ public class LibraryService {
                 .put("version", pack.getMetadata().getVersion())
                 .put("path", pack.getPath().getFileName().toString())
                 .put("timestamp", pack.getTimestamp())
+                .put("sizeInBytes", sizeOnDisk(pack.getPath().toFile()))
                 .put("nightModeAvailable", pack.getMetadata().isNightModeAvailable());
         Optional.ofNullable(pack.getMetadata().getTitle()).ifPresent(title -> json.put("title", title));
         Optional.ofNullable(pack.getMetadata().getDescription()).ifPresent(desc -> json.put("description", desc));
@@ -505,6 +506,23 @@ public class LibraryService {
                         .put("official", metadata.isOfficial())
                 )
                 .orElse(json);
+    }
+
+    /**
+     * Size on disk (in bytes) of a pack file or folder (FS format packs are directories).
+     * Used by the frontend to estimate whether a transfer will fit in the device's remaining space.
+     */
+    public long packSizeInBytes(String relativePackPath) {
+        return sizeOnDisk(new File(libraryPath() + relativePackPath));
+    }
+
+    private long sizeOnDisk(File file) {
+        try {
+            return file.isDirectory() ? FileUtils.sizeOfDirectory(file) : Files.size(file.toPath());
+        } catch (IOException e) {
+            LOGGER.warn("Failed to compute size on disk for " + file, e);
+            return 0L;
+        }
     }
 
 }

--- a/web-ui/src/main/resources/webroot/locales/en/translation.json
+++ b/web-ui/src/main/resources/webroot/locales/en/translation.json
@@ -188,6 +188,8 @@
         "failure": "Story Teller failure."
       },
       "busy": "Device is busy. Wait for any other device-related operation to finish.",
+      "queued": "Queued. Waiting for the current device operation to finish...",
+      "notEnoughSpace": "Not enough estimated space left on the device for this story pack.",
       "checking": "Checking device...",
       "plugged": "Device is plugged.",
       "checkingFailed": "Failed to check device.",

--- a/web-ui/src/main/resources/webroot/locales/fr/translation.json
+++ b/web-ui/src/main/resources/webroot/locales/fr/translation.json
@@ -188,6 +188,8 @@
         "failure": "Échec d'accès à la fabrique à histoires."
       },
       "busy": "L'appareil n'est pas disponible. Attendez la fin de toute autre opération liée à l'appareil.",
+      "queued": "En file d'attente. En attente de la fin de l'opération en cours sur l'appareil...",
+      "notEnoughSpace": "Espace estimé insuffisant sur l'appareil pour ce pack d'histoires.",
       "checking": "Vérification de l'appareil...",
       "plugged": "L'appareil est branché.",
       "checkingFailed": "Échec de la vérification de l'appareil.",


### PR DESCRIPTION
## Summary

Previously, starting a transfer to/from the device while another one was in progress would just fail with a "device is busy" error, forcing the user to wait and manually retry. Transfer-related actions (add to device, remove from device, reorder, add to library) now queue up on the same mutex that serializes device (USB) operations, instead of racing against a short timeout. Quick status checks (device plugged/refresh) keep the previous fail-fast behavior since queuing those wouldn't be useful.

- Adds a pre-transfer check of the device's estimated remaining space before queueing a transfer to the device, accounting for transfers already queued/in-flight so several queued additions can't collectively overflow the device. Relies on a new `sizeInBytes` field now exposed for library packs (computed from the actual file, or recursive folder size for FS-format packs) and for freshly converted packs.
- Fixes a spurious "device is busy" toast that appeared after every queued transfer completed (the automatic post-transfer device refresh was racing against the next queued transfer using a fail-fast mutex view; it now fails silently since it's non-critical and self-corrects).
- Adds a stall-timeout safety net: if a transfer's completion event is never received (observed when the device disconnects mid-transfer), the transfer is treated as failed after 60s instead of leaving the queue blocked forever.

## Test plan

- [x] Verified queuing works: dropping several packs in a row processes them sequentially instead of erroring out
- [x] Verified against a real device that a stalled/lost completion event no longer blocks the queue
- [x] Full `mvn clean install` build passes