### PR TITLE
Avoid double-logging the same exception when the update check fails

### DIFF
--- a/web-ui/src/main/java/studio/webui/MainVerticle.java
+++ b/web-ui/src/main/java/studio/webui/MainVerticle.java
@@ -93,7 +93,11 @@ public class MainVerticle extends AbstractVerticle {
         ErrorHandler errorHandler = ErrorHandler.create(true);
         router.route().failureHandler(ctx -> {
             Throwable failure = ctx.failure();
-            LOGGER.error("Exception thrown", failure);
+            if (failure != null) {
+                // Failures whose cause was already logged by their handler are reported via
+                // ctx.fail(statusCode) with no attached Throwable, to avoid double-logging.
+                LOGGER.error("Exception thrown", failure);
+            }
             errorHandler.handle(ctx);
         });
 

--- a/web-ui/src/main/java/studio/webui/api/EvergreenController.java
+++ b/web-ui/src/main/java/studio/webui/api/EvergreenController.java
@@ -28,8 +28,10 @@ public class EvergreenController {
                             .putHeader("content-type", "application/json")
                             .end(Json.encode(maybeJson.result()));
                 } else {
-                    LOGGER.error("Failed to get current version infos");
-                    ctx.fail(500, maybeJson.cause());
+                    LOGGER.error("Failed to get current version infos", maybeJson.cause());
+                    // Don't propagate the cause: it is already logged here, and the global failure
+                    // handler would otherwise log the same (often benign, e.g. offline) exception again.
+                    ctx.fail(500);
                 }
             });
         });
@@ -42,8 +44,10 @@ public class EvergreenController {
                             .putHeader("content-type", "application/json")
                             .end(Json.encode(maybeJson.result()));
                 } else {
-                    LOGGER.error("Failed to get latest release");
-                    ctx.fail(500, maybeJson.cause());
+                    LOGGER.error("Failed to get latest release", maybeJson.cause());
+                    // Don't propagate the cause: it is already logged here, and the global failure
+                    // handler would otherwise log the same (often benign, e.g. offline) exception again.
+                    ctx.fail(500);
                 }
             });
         });
@@ -56,8 +60,10 @@ public class EvergreenController {
                             .putHeader("content-type", "application/json")
                             .end(Json.encode(maybeJson.result()));
                 } else {
-                    LOGGER.error("Failed to get announce");
-                    ctx.fail(500, maybeJson.cause());
+                    LOGGER.error("Failed to get announce", maybeJson.cause());
+                    // Don't propagate the cause: it is already logged here, and the global failure
+                    // handler would otherwise log the same (often benign, e.g. offline) exception again.
+                    ctx.fail(500);
                 }
             });
         });


### PR DESCRIPTION
## Summary

When the app can't reach api.github.com to check for updates (e.g. no internet connection), the failure was logged once with a short message in `EvergreenController`, then re-logged with a full stack trace by the generic router failure handler in `MainVerticle`. That second log made a routine, already-handled, and often entirely expected failure (offline) look like a crash in the console.

The full stack trace is still logged exactly once (in the controller, where the actual failure occurs); `ctx.fail()` is now called without the cause so the generic handler doesn't log it again. Other controllers are untouched, since their failures are typically not benign/expected.

## Test plan

- [x] Verified offline: only one log line for the failure instead of three stack traces
- [x] Full `mvn clean install` build passes