### PR TITLE
Don't let one unreadable device pack break the whole device pack list

### DIFF
--- a/driver/src/main/java/studio/driver/fs/FsStoryTellerAsyncDriver.java
+++ b/driver/src/main/java/studio/driver/fs/FsStoryTellerAsyncDriver.java
@@ -255,10 +255,10 @@ public class FsStoryTellerAsyncDriver {
 
         return readPackIndex()
                 .thenApply(packUUIDs -> {
-                    try {
-                        LOGGER.fine("Number of packs in index: " + packUUIDs.size());
-                        List<FsStoryPackInfos> packs = new ArrayList<>();
-                        for (UUID packUUID : packUUIDs) {
+                    LOGGER.fine("Number of packs in index: " + packUUIDs.size());
+                    List<FsStoryPackInfos> packs = new ArrayList<>();
+                    for (UUID packUUID : packUUIDs) {
+                        try {
                             FsStoryPackInfos packInfos = new FsStoryPackInfos();
                             packInfos.setUuid(packUUID);
                             LOGGER.fine("Pack UUID: " + packUUID.toString());
@@ -286,11 +286,13 @@ public class FsStoryTellerAsyncDriver {
                             packInfos.setSizeInBytes((int) FileUtils.getFolderSize(packFolderPath));
 
                             packs.add(packInfos);
+                        } catch (Exception e) {
+                            // A single unreadable/incomplete pack folder (e.g. left over from an interrupted
+                            // transfer) must not prevent listing the rest of the device's packs.
+                            LOGGER.log(Level.WARNING, "Failed to read pack metadata on device partition for pack: " + packUUID, e);
                         }
-                        return packs;
-                    } catch (Exception e) {
-                        throw new StoryTellerException("Failed to read pack metadata on device partition", e);
                     }
+                    return packs;
                 });
     }
 
@@ -488,7 +490,20 @@ public class FsStoryTellerAsyncDriver {
                         } catch (IOException e) {
                             throw new StoryTellerException("Failed to copy pack from device", e);
                         }
-                    })).thenCompose(status -> {
+                    })).whenComplete((status, ex) -> {
+                        if (ex != null) {
+                            // The pack's UUID is only added to the index once the copy succeeds (below), so a
+                            // failed copy never leaves a *listed* pack behind. But partially-written files/folders
+                            // may still be sitting on the device -- clean them up so they don't linger as wasted
+                            // (and potentially inconsistent) space.
+                            try {
+                                LOGGER.info("Cleaning up partially transferred pack folder after failed upload: " + destFolder);
+                                org.apache.commons.io.FileUtils.deleteDirectory(destFolder);
+                            } catch (IOException cleanupException) {
+                                LOGGER.log(Level.WARNING, "Failed to clean up partially transferred pack folder: " + destFolder, cleanupException);
+                            }
+                        }
+                    }).thenCompose(status -> {
                         // Finally, add pack UUID to index
                         return readPackIndex()
                                 .thenCompose(packUUIDs -> {


### PR DESCRIPTION
## Summary

`getPacksList()` read every pack's metadata inside a single try/catch around the whole loop, so a single corrupted/incomplete pack folder (e.g. left over from an interrupted transfer after an I/O error) made the *entire* device pack list fail -- the device became unusable in the UI until the bad pack was manually removed from the SD card.

Moves the try/catch inside the loop: an unreadable pack is now skipped (logged as a warning) instead of aborting the whole list.

Also cleans up the partially-written destination folder when `uploadPack` fails, so an interrupted transfer doesn't leave one behind in the first place.

## Test plan

- [x] Reproduced against a real device with a corrupted pack folder (left over from an interrupted transfer): before this fix, the device pack list failed entirely; after, the bad pack is skipped with a warning and the rest of the packs list normally
- [x] Full `mvn clean install` build passes